### PR TITLE
Fixed the bug when there are no customtypeProducts available. 

### DIFF
--- a/Model/Product/Link/CollectionProvider/CustomType.php
+++ b/Model/Product/Link/CollectionProvider/CustomType.php
@@ -9,6 +9,12 @@ class CustomType implements \Magento\Catalog\Model\ProductLink\CollectionProvide
      */
     public function getLinkedProducts(\Magento\Catalog\Model\Product $product)
     {
-        return $product->getCustomTypeProducts();
+        $products = $product->getCustomtypeProducts();
+
+        if (!isset($products)) {
+            return [];
+        }
+
+        return $products;
     }
 }


### PR DESCRIPTION
Returns an array instead of null if there are no products available.
Also one typo.