### PR TITLE
Issue #13: Return the Link object because it is necessary for afterSaveProductRelations()

### DIFF
--- a/Model/Catalog/Product/Link.php
+++ b/Model/Catalog/Product/Link.php
@@ -29,5 +29,7 @@ class Link extends \Magento\Catalog\Model\Product\Link
         if (!is_null($data)) {
             $this->_getResource()->saveProductLinks($product->getId(), $data, self::LINK_TYPE_CUSTOMTYPE);
         }
+
+        return $this;
     }
 }


### PR DESCRIPTION
This PR solves not being able to save products because the preference Link object does not return a Link object. Therefore all other plugins after that fail and a fatal error is generated.